### PR TITLE
:bug: Replace discontinued logo API

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,9 +12,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install and build
+    - name: Yarn install and build
       run: |
-        npm install
-        npm run build
+        npm install --global yarn@1.22.22
+        yarn install --frozen-lockfile
+        yarn build
       env:
         CI: true

--- a/pages/chat/_id.vue
+++ b/pages/chat/_id.vue
@@ -26,7 +26,7 @@
 		</section>
 		<section v-else class="messages">
 			<article v-if="item.text !== 'bot__meta:START' && item.text !== 'bot__meta:STOP'" v-for="(item, index) in messages" :key="'m_' + index" :class="((item.from === $store.state.user.profile.uid && !item.from_bot) ? 'mine' : 'not_mine') + ' ' + (item.prevSame ? 'prev_same' : 'prev_not_same') + ' ' + (item.nextSame ? 'next_same' : 'next_not_same')">
-				<img v-if="item.from_bot" alt="Image" src="https://logo.clearbit.com/cls-group.com" class="small-dp">
+				<img v-if="item.from_bot" alt="Image" src="https://www.google.com/s2/favicons?sz=128&domain=cls-group.com" class="small-dp">
 				<img v-else alt="Image" :src="getUser(item.from).photoUrl" class="small-dp">
 				<div class="bubble">{{item.text}}</div>
 			</article>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,11 +2505,10 @@ etag@^1.8.1, etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
 event-stream@~3.3.0:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.6.tgz#cac1230890e07e73ec9cacd038f60a5b66173eef"
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.5.tgz#e5dd8989543630d94c6cf4d657120341fa31636b"
   dependencies:
     duplexer "^0.1.1"
-    flatmap-stream "^0.1.0"
     from "^0.1.7"
     map-stream "0.0.7"
     pause-stream "^0.0.11"
@@ -2752,10 +2751,6 @@ firebase@^5.5.8:
     "@firebase/messaging" "0.3.6"
     "@firebase/polyfill" "0.3.3"
     "@firebase/storage" "0.2.4"
-
-flatmap-stream@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/flatmap-stream/-/flatmap-stream-0.1.1.tgz#d34f39ef3b9aa5a2fc225016bd3adf28ac5ae6ea"
 
 flatten@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary
- Replace the deprecated Clearbit Logo API URL with the Google favicon endpoint for the bot avatar
- Update the locked event-stream tarball from unavailable 3.3.6 to published 3.3.5 so dependency installation works again
- Switch CI to Yarn 1 with `--frozen-lockfile` so the workflow uses the committed lockfile instead of resolving incompatible newer Nuxt dependencies

Fixes #2

## Test plan
- `curl -fsSIL` the replacement favicon endpoint (returns 200 image/png after redirect)
- `npx -y -p node@8 -p yarn@1.22.22 yarn install --frozen-lockfile`
- `npx -y -p node@8 -p yarn@1.22.22 yarn build`
- `npx -y -p node@10 -p yarn@1.22.22 yarn install --frozen-lockfile`
- `npx -y -p node@10 -p yarn@1.22.22 yarn build`
- Workflow YAML parsed locally with PyYAML
